### PR TITLE
📝 docs(adr): add ADR-0004 for live infra signal via docker-socket-proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — docs (2026-07-16)
+
+- **ADR-0004 — live infra signal via the docker-socket-proxy.** Records the decision to source the portfolio's public container/stack counts from the existing read-only `dockerproxy` (`/containers/json` list only) rather than Prometheus/cAdvisor, and why the backend (`portfolio-api`) — already co-networked on `space-server_web` — hosts the query. No infra change in this repo; documentation only.
+
 ### Added — admin VPN (WireGuard + Traefik allowlist) (2026-06-04)
 
 - **WireGuard admin VPN on polaris2 (F47).** Installed `wireguard`; `wg0` = `10.10.0.1/24` on UDP `51820`, services-only tunnel (no NAT/full-tunnel), `wg-quick@wg0` enabled on boot, ufw opened for `51820/udp`. Keys + `wg0.conf` live in `/etc/wireguard/` (root, 0600) — **never in git**.

--- a/docs/decisions/0004-live-infra-signal-via-docker-socket-proxy.md
+++ b/docs/decisions/0004-live-infra-signal-via-docker-socket-proxy.md
@@ -1,0 +1,71 @@
+# ADR-0004: Live container/stack counts via the docker-socket-proxy
+
+## Status
+
+accepted (2026-07-16)
+
+## Context
+
+The portfolio's public "SIGNAL · PROOF OF WORK" panel displays a self-hosting
+metric — `containers` and `stacks` — under a `LIVE` badge. Those numbers were
+hardcoded (`16 containers · 6 stacks`) and had already drifted from reality: this
+repo's own README states ~20 containers across ~12 compose projects. A skeptical
+reviewer comparing the public site to the public `space-server` README would catch
+the discrepancy, which undermines the credibility the panel is meant to project.
+
+We need a live source for the running-container count and the distinct
+docker-compose-project (stack) count that `portfolio-api` can read at request time.
+
+Two live sources already exist on the host:
+
+- **cAdvisor via Prometheus** (`monitoring` network, exposed only behind
+  `internal-only@file` + `auth@file`).
+- **`dockerproxy`** — the read-only `tecnativa/docker-socket-proxy` on the `web`
+  (`space-server_web`) network, already fronting `/var/run/docker.sock:ro` for
+  Traefik with `CONTAINERS=1`.
+
+## Decision
+
+`portfolio-api` derives the counts by calling `GET dockerproxy:2375/containers/json`
+(running containers = list length; stacks = distinct `com.docker.compose.project`
+labels) and exposes them at `GET /infra/stats`. The Nuxt BFF's `/api/signal`
+aggregates that endpoint alongside its existing GitHub/npm/health calls.
+
+## Alternatives considered
+
+- **Prometheus/cAdvisor** — metrics-only surface (safer), but requires attaching
+  `portfolio-api` to the `monitoring` network (an infra change), carries scrape
+  lag, and counting via PromQL label-dedup is more brittle than a direct list.
+  Rejected: higher operational cost for no accuracy gain.
+- **Mount `/var/run/docker.sock` into `portfolio-api`** — rejected: violates
+  least-privilege; the socket-proxy exists precisely to avoid raw-socket access.
+- **Query dockerproxy from the Nuxt BFF directly** — fewer repos touched (the
+  portfolio container is also on `space-server_web`), but embeds docker-API access
+  in the public-facing frontend, against the app↔API separation goal. Rejected in
+  favour of routing through the backend, mirroring how `/api/signal` already
+  fetches `api.cativo.dev`.
+
+## Consequences
+
+### Positive
+
+- **Zero infra change.** `portfolio-api` and `dockerproxy` already share
+  `space-server_web`, so `dockerproxy:2375` resolves with no compose edit; the
+  API defaults `DOCKER_PROXY_URL` to `http://dockerproxy:2375`.
+- The panel's `LIVE` numbers become verifiable and self-correct as the host grows.
+- Real-time and exact — no scrape lag, no metric-label guessing.
+
+### Negative
+
+- `CONTAINERS=1` also gates `/containers/{id}/json` (inspect → env vars), so
+  `portfolio-api` *gains the capability* to inspect containers. Mitigation: the
+  service calls **only** the `/containers/json` list endpoint (no env is ever
+  read), the endpoint is read-only and cached, and the network path already
+  existed — this is new *usage*, not new *exposure*.
+- Adds `dockerproxy` as a soft runtime dependency of `/infra/stats`. Mitigation:
+  the service degrades to `null` counts on any failure; the panel renders `…`.
+
+### Follow-ups
+
+- If `portfolio-api` ever needs richer host metrics, revisit the Prometheus path
+  (and the `monitoring`-network attach) rather than widening the proxy surface.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -20,6 +20,7 @@ Format: lightweight [Michael Nygard ADR](https://cognitect.com/blog/2011/11/15/d
 | [0001](0001-single-source-of-truth.md) | Repository as single source of truth for infrastructure | accepted |
 | [0002](0002-observability-before-features.md) | Adopt observability before scaling features | accepted |
 | [0003](0003-smtp-relay-via-resend.md) | Route outbound mail through Resend SMTP relay | accepted |
+| [0004](0004-live-infra-signal-via-docker-socket-proxy.md) | Live container/stack counts via the docker-socket-proxy | accepted |
 
 ## Adding a new ADR
 


### PR DESCRIPTION
## What

Adds **ADR-0004** documenting the decision behind the portfolio's now-live container/stack counts:
- **Source:** the existing read-only `dockerproxy` (`/containers/json` list only — never inspect), not Prometheus/cAdvisor.
- **Placement:** `portfolio-api` hosts the query (already co-networked on `space-server_web` → **zero infra change**), consumed by the Nuxt BFF.

## Scope

Documentation only — no compose/service change in this repo. Indexed in `docs/decisions/README.md`; brief `[Unreleased]` CHANGELOG note added.

## Related

- portfolio-api#141 (endpoint), portfolio#140 (frontend).